### PR TITLE
Add @dantzig_wolfe macro for declarative decomposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 ReformulationKit automatically rewrites JuMP models into decomposed forms (e.g., Dantzig-Wolfe), based on simple annotations. It generates the master and subproblem models, letting you focus on modeling while it handles the reformulation logic.
 
+
 ## Quick Example
 
 ```julia
 using JuMP, ReformulationKit
-
-const RK = ReformulationKit
 
 # Create original model
 model = Model()
@@ -16,17 +15,16 @@ model = Model()
 @constraint(model, capacity[m in 1:2], sum(x[m,j] for j in 1:3) <= 2)
 @objective(model, Min, sum(x[m,j] for m in 1:2, j in 1:3))
 
-# Define annotations: which variables/constraints go where
-dw_annotation(::Val{:x}, machine, job) = RK.dantzig_wolfe_subproblem(machine)
-dw_annotation(::Val{:demand}, job) = RK.dantzig_wolfe_master()
-dw_annotation(::Val{:capacity}, machine) = RK.dantzig_wolfe_subproblem(machine)
-
-# Decompose automatically
-reformulation = RK.dantzig_wolfe_decomposition(model, dw_annotation)
+# Decompose with declarative syntax
+reformulation = @dantzig_wolfe model begin
+    x[m, _] => subproblem(m)         # Variables x[m,j] go to subproblem m
+    demand[_] => master()            # Demand constraints go to master
+    capacity[m] => subproblem(m)     # Capacity constraints go to subproblem m
+end
 
 # Access results
-master = RK.master(reformulation)      # Master problem with coupling constraints
-subproblems = RK.subproblems(reformulation)    # Dict of subproblem models by ID
+master = master(reformulation)             # Master problem with coupling constraints
+subproblems = subproblems(reformulation)   # Dict of subproblem models by ID
 ```
 
 The package handles all the complex reformulation logic - variable mapping, constraint translation, objective decomposition, and column generation setup.

--- a/src/ReformulationKit.jl
+++ b/src/ReformulationKit.jl
@@ -20,6 +20,7 @@ include("dantzig_wolfe/mappings.jl")
 include("dantzig_wolfe/reformulation.jl")
 include("dantzig_wolfe/partitionning.jl")
 include("dantzig_wolfe/models.jl")
+include("dantzig_wolfe/macro.jl")
 
 
 """
@@ -173,6 +174,6 @@ function dantzig_wolfe_decomposition(model::Model, dw_annotation)
     return DantzigWolfeReformulation(master_model, subproblem_models, convexity_constraints_lb, convexity_constraints_ub)
 end
 
-export dantzig_wolfe_decomposition, dantzig_wolfe_subproblem, dantzig_wolfe_master
+export dantzig_wolfe_decomposition, dantzig_wolfe_subproblem, dantzig_wolfe_master, @dantzig_wolfe
 
 end # module ReformulationKit

--- a/src/dantzig_wolfe/macro.jl
+++ b/src/dantzig_wolfe/macro.jl
@@ -1,0 +1,177 @@
+# Copyright (c) 2025 Nablarise. All rights reserved.
+# Author: Guillaume Marques <guillaume@nablarise.com>
+# SPDX-License-Identifier: Proprietary
+
+struct SubproblemAssignment
+    id_expr::Any
+end
+
+struct MasterAssignment
+end
+
+struct PatternRule
+    name::Symbol
+    indices::Vector{Symbol}
+    assignment::Union{SubproblemAssignment, MasterAssignment}
+end
+
+
+"""
+    @dantzig_wolfe model begin
+        pattern => assignment
+        ...
+    end
+
+Macro for declarative Dantzig-Wolfe decomposition specification.
+
+# Pattern Syntax
+- `constraint_name[index1, index2, ...]` - constraint or variable pattern
+- `_` - wildcard for ignored indices  
+- `variable_name` - captured index used in assignment
+
+# Assignment Syntax
+- `subproblem(id)` - assign to subproblem with given ID
+- `master()` - assign to master problem
+
+# Example
+```julia
+@dantzig_wolfe model begin
+    assignment[m, _] => subproblem(m)     # assignment constraint to subproblem m
+    knapsack[m] => subproblem(m)          # knapsack constraint to subproblem m  
+    coverage[_] => master()               # coverage constraint to master
+end
+```
+
+This generates an annotation function and calls `dantzig_wolfe_decomposition(model, annotation_fn)`.
+"""
+macro dantzig_wolfe(model, block)
+    patterns = parse_block(block)
+    fn_name = gensym("generated_annotation")
+    method_defs = generate_method_definitions(fn_name, patterns)
+    
+    return quote
+        $(method_defs...)
+        dantzig_wolfe_decomposition($(esc(model)), $fn_name)
+    end
+end
+
+function parse_block(block::Expr)
+    if block.head != :block
+        error("Expected begin...end block")
+    end
+    
+    patterns = PatternRule[]
+    for line in block.args
+        if line isa LineNumberNode
+            continue
+        end
+        
+        if line isa Expr && line.head == :call && length(line.args) == 3 && line.args[1] == :(=>)
+            pattern, assignment = line.args[2], line.args[3]
+            push!(patterns, parse_pattern_rule(pattern, assignment))
+        else
+            error("Expected pattern => assignment, got: $line")
+        end
+    end
+    
+    if isempty(patterns)
+        error("No patterns specified in @dantzig_wolfe block")
+    end
+    
+    return patterns
+end
+
+function parse_pattern_rule(pattern, assignment::Expr)
+    name, indices = parse_pattern(pattern)
+    assign = parse_assignment(assignment)
+    return PatternRule(name, indices, assign)
+end
+
+function parse_pattern(pattern)
+    if pattern isa Symbol
+        # Handle patterns without indices like: x => subproblem(1)
+        return pattern, Symbol[]
+    elseif pattern isa Expr && pattern.head == :ref
+        name = pattern.args[1]
+        if !(name isa Symbol)
+            error("Pattern name must be a symbol, got: $name")
+        end
+        indices = pattern.args[2:end]
+        
+        index_symbols = Symbol[]
+        for idx in indices
+            if idx isa Symbol
+                push!(index_symbols, idx)
+            else
+                error("Index must be a symbol or _, got: $idx")
+            end
+        end
+        
+        return name, index_symbols
+    else
+        error("Expected pattern[indices] or pattern, got: $pattern")
+    end
+end
+
+function parse_assignment(assignment::Expr)
+    if assignment.head == :call
+        func_name = assignment.args[1]
+        
+        if func_name == :subproblem
+            if length(assignment.args) != 2
+                error("subproblem() requires exactly one argument")
+            end
+            id_expr = assignment.args[2]
+            return SubproblemAssignment(id_expr)
+            
+        elseif func_name == :master
+            if length(assignment.args) != 1
+                error("master() takes no arguments")
+            end
+            return MasterAssignment()
+        else
+            error("Unknown assignment function: $func_name")
+        end
+    else
+        error("Expected function call for assignment, got: $assignment")
+    end
+end
+
+function generate_method_definitions(fn_name::Symbol, patterns::Vector{PatternRule})
+    method_defs = Expr[]
+    
+    for pattern in patterns
+        method_def = generate_method_definition(fn_name, pattern)
+        push!(method_defs, method_def)
+    end
+    
+    return method_defs
+end
+
+function generate_method_definition(fn_name::Symbol, pattern::PatternRule)
+    # Create the Val type parameter
+    val_param = :(::Val{$(QuoteNode(pattern.name))})
+    
+    # Create the parameter list: (::Val{:name}, indices...)
+    if isempty(pattern.indices)
+        params = [val_param]
+    else
+        params = [val_param, pattern.indices...]
+    end
+    
+    # Generate the assignment expression
+    assignment_expr = generate_assignment_expr(pattern.assignment)
+    
+    # Create the method definition
+    return :(function $fn_name($(params...))
+        $assignment_expr
+    end)
+end
+
+function generate_assignment_expr(assignment::SubproblemAssignment)
+    return :(dantzig_wolfe_subproblem($(assignment.id_expr)))
+end
+
+function generate_assignment_expr(::MasterAssignment)
+    return :(dantzig_wolfe_master())
+end

--- a/src/dantzig_wolfe/models.jl
+++ b/src/dantzig_wolfe/models.jl
@@ -26,7 +26,6 @@ function _original_var_info(original_model, var_name, index)
     )
 end
 
-
 function _replace_vars_in_func(func::JuMP.AffExpr, target_model, original_to_subproblem_vars_mapping::VariableMapping; preserve_constant::Bool = true)
     terms = [
         original_to_subproblem_vars_mapping[var] => coeff 
@@ -47,6 +46,7 @@ end
 # Create and register variables in reform model, updating variable mapping
 function _register_variables!(reform_model, original_to_reform_mapping::VariableMapping, original_model, var_infos_by_names)
     for (var_name, var_infos_by_indexes) in var_infos_by_names
+        indices = sort(collect(keys(var_infos_by_indexes)))
         vars = Containers.container(
             (index...) -> begin
                 var = JuMP.build_variable(() -> error("todo."), var_infos_by_indexes[index])
@@ -58,7 +58,7 @@ function _register_variables!(reform_model, original_to_reform_mapping::Variable
                 original_var = get_scalar_object(original_model, var_name, index)
                 original_to_reform_mapping[original_var] = JuMP.add_variable(reform_model, var, jump_var_name)
             end,
-            sort(collect(keys(var_infos_by_indexes)))
+            indices
         )
         reform_model[var_name] = vars
     end
@@ -67,6 +67,7 @@ end
 # Create and register constraints in reform model using mapped variables
 function _register_constraints!(reform_model, original_to_reform_constr_mapping::ConstraintMapping, original_model, constr_by_names, original_to_reform_vars_mapping::VariableMapping)
     for (constr_name, constr_by_indexes) in constr_by_names
+        indices = sort(collect(constr_by_indexes))
         constrs = JuMP.Containers.container(
             (index...) -> begin
                 original_constr = get_scalar_object(original_model, constr_name, index)
@@ -84,7 +85,7 @@ function _register_constraints!(reform_model, original_to_reform_constr_mapping:
                 end
                 original_to_reform_constr_mapping[original_constr] = JuMP.add_constraint(reform_model, constr, jump_constr_name)
             end,
-            sort(collect(constr_by_indexes))
+            indices
         )
         reform_model[constr_name] = constrs
     end

--- a/src/dantzig_wolfe/partitionning.jl
+++ b/src/dantzig_wolfe/partitionning.jl
@@ -1,6 +1,6 @@
 # Partition variables annotated for master problem by variable name and index
 function _master_variables(model, dw_annotation)
-    master_vars = Dict{Symbol,Set{Tuple}}()
+    master_vars = Dict{Symbol,Any}()
 
     for (var_name, var_obj) in object_dictionary(model)
         # Only process variables, not constraints
@@ -18,7 +18,7 @@ function _master_variables(model, dw_annotation)
             annotation = dw_annotation(Val(var_name))
             if annotation isa MasterAnnotation
                 if !haskey(master_vars, var_name)
-                    master_vars[var_name] = Set{Tuple}([()])
+                    master_vars[var_name] = Set{Tuple{}}([()])
                 end
             end
         end
@@ -28,7 +28,7 @@ end
 
 # Partition variables by subproblem ID based on annotations
 function _partition_subproblem_variables(model, dw_annotation)
-    sp_vars_partitionning = Dict{Any,Dict{Symbol,Set{Tuple}}}()
+    sp_vars_partitionning = Dict{Any,Dict{Symbol,Any}}()
     for (var_name, var_obj) in object_dictionary(model)
         # Only process variables, not constraints
         if var_obj isa AbstractArray && length(var_obj) > 0 && first(var_obj) isa AbstractVariableRef
@@ -36,7 +36,7 @@ function _partition_subproblem_variables(model, dw_annotation)
                 annotation = dw_annotation(Val(var_name), Tuple(idx)...)
                 if annotation isa SubproblemAnnotation
                     if !haskey(sp_vars_partitionning, annotation.id)
-                        sp_vars_partitionning[annotation.id] = Dict{Symbol,Set{Tuple}}()
+                        sp_vars_partitionning[annotation.id] = Dict{Symbol,Any}()
                     end
                     if !haskey(sp_vars_partitionning[annotation.id], var_name)
                         sp_vars_partitionning[annotation.id][var_name] = Set{Tuple}()
@@ -48,10 +48,10 @@ function _partition_subproblem_variables(model, dw_annotation)
             annotation = dw_annotation(Val(var_name))
             if annotation isa SubproblemAnnotation
                 if !haskey(sp_vars_partitionning, annotation.id)
-                    sp_vars_partitionning[annotation.id] = Dict{Symbol,Set{Tuple}}()
+                    sp_vars_partitionning[annotation.id] = Dict{Symbol,Any}()
                 end
                 if !haskey(sp_vars_partitionning[annotation.id], var_name)
-                    sp_vars_partitionning[annotation.id][var_name] = Set{Tuple}([()])
+                    sp_vars_partitionning[annotation.id][var_name] = Set{Tuple{}}([()])
                 end
             end
         end
@@ -61,7 +61,7 @@ end
 
 # Partition constraints annotated for master problem by constraint name and index
 function _master_constraints(model, dw_annotation)
-    master_constrs = Dict{Symbol,Set{Tuple}}()
+    master_constrs = Dict{Symbol,Any}()
 
     for (constr_name, constr_obj) in object_dictionary(model)
         # Only process constraints, not variables
@@ -79,7 +79,7 @@ function _master_constraints(model, dw_annotation)
             annotation = dw_annotation(Val(constr_name))
             if annotation isa MasterAnnotation
                 if !haskey(master_constrs, constr_name)
-                    master_constrs[constr_name] = Set{Tuple}([()])
+                    master_constrs[constr_name] = Set{Tuple{}}([()])
                 end
             end
         end
@@ -89,7 +89,7 @@ end
 
 # Partition constraints by subproblem ID based on annotations
 function _partition_subproblem_constraints(model, dw_annotation)
-    sp_constrs_partitionning = Dict{Any,Dict{Symbol,Set{Tuple}}}()
+    sp_constrs_partitionning = Dict{Any,Dict{Symbol,Any}}()
     for (constr_name, constr_obj) in object_dictionary(model)
         # Only process constraints, not variables
         if constr_obj isa AbstractArray && length(constr_obj) > 0 && first(constr_obj) isa ConstraintRef
@@ -97,7 +97,7 @@ function _partition_subproblem_constraints(model, dw_annotation)
                 annotation = dw_annotation(Val(constr_name), Tuple(idx)...)
                 if annotation isa SubproblemAnnotation
                     if !haskey(sp_constrs_partitionning, annotation.id)
-                        sp_constrs_partitionning[annotation.id] = Dict{Symbol,Set{Tuple}}()
+                        sp_constrs_partitionning[annotation.id] = Dict{Symbol,Any}()
                     end
                     if !haskey(sp_constrs_partitionning[annotation.id], constr_name)
                         sp_constrs_partitionning[annotation.id][constr_name] = Set{Tuple}()
@@ -109,10 +109,10 @@ function _partition_subproblem_constraints(model, dw_annotation)
             annotation = dw_annotation(Val(constr_name))
             if annotation isa SubproblemAnnotation
                 if !haskey(sp_constrs_partitionning, annotation.id)
-                    sp_constrs_partitionning[annotation.id] = Dict{Symbol,Set{Tuple}}()
+                    sp_constrs_partitionning[annotation.id] = Dict{Symbol,Any}()
                 end
                 if !haskey(sp_constrs_partitionning[annotation.id], constr_name)
-                    sp_constrs_partitionning[annotation.id][constr_name] = Set{Tuple}([()])
+                    sp_constrs_partitionning[annotation.id][constr_name] = Set{Tuple{}}([()])
                 end
             end
         end

--- a/test/ReformulationKitUnitTests/ReformulationKitUnitTests.jl
+++ b/test/ReformulationKitUnitTests/ReformulationKitUnitTests.jl
@@ -154,6 +154,7 @@ include("dantzig_wolfe/partitionning.jl")
 include("dantzig_wolfe/models.jl")
 include("dantzig_wolfe/reformulation.jl")
 include("dantzig_wolfe/main.jl")
+include("dantzig_wolfe/macro.jl")
 
 function run()
     @testset "ReformulationKit Unit Tests" begin
@@ -162,6 +163,7 @@ function run()
         test_unit_models()
         test_unit_reformulation_structure()
         test_unit_main_decomposition()
+        test_unit_macro()
     end
 end
 

--- a/test/ReformulationKitUnitTests/dantzig_wolfe/macro.jl
+++ b/test/ReformulationKitUnitTests/dantzig_wolfe/macro.jl
@@ -1,0 +1,263 @@
+# Copyright (c) 2025 Nablarise. All rights reserved.
+# Author: Guillaume Marques <guillaume@nablarise.com>
+# SPDX-License-Identifier: Proprietary
+
+function test_macro_basic_gap_ok()
+    J = 1:2
+    M = 1:2
+    c = [1 2; 3 4]
+    
+    model = Model()
+    @variable(model, x[M, J], Bin)
+    @constraint(model, assignment[j in J], sum(x[m, j] for m in M) >= 1)
+    @constraint(model, capacity[m in M], sum(x[m, j] for j in J) <= 2)
+    @objective(model, Min, sum(c[m, j] * x[m, j] for m in M, j in J))
+    
+    reformulation = @dantzig_wolfe model begin
+        x[m, _] => subproblem(m)
+        assignment[_] => master()
+        capacity[m] => subproblem(m)
+    end
+    
+    @test reformulation isa RK.DantzigWolfeReformulation
+    @test length(RK.subproblems(reformulation)) == 2
+    
+    master = RK.master(reformulation)
+    @test JuMP.num_variables(master) == 0  # No master variables in this GAP
+    
+    subproblems = RK.subproblems(reformulation)
+    for (m, sp) in subproblems
+        @test JuMP.num_variables(sp) == 2  # x variables for 2 jobs
+        @test haskey(sp.obj_dict, :x)
+        @test haskey(sp.obj_dict, :capacity)
+    end
+end
+
+function test_macro_gap_with_penalties_ok()
+    machines = 1:2
+    jobs = 1:3
+    assignment_costs = [1 2 3; 4 5 6]
+    penalty_costs = [10, 12, 8]
+    capacities = [2, 2]
+    
+    model = Model()
+    @variable(model, x[machines, jobs], Bin)
+    @variable(model, penalty[jobs] >= 0)
+    @constraint(model, assignment[j in jobs], 
+                sum(x[m, j] for m in machines) + penalty[j] >= 1)
+    @constraint(model, capacity_constr[m in machines], 
+                sum(x[m, j] for j in jobs) <= capacities[m])
+    @objective(model, Min, 
+               sum(assignment_costs[m, j] * x[m, j] for m in machines, j in jobs) + 
+               sum(penalty_costs[j] * penalty[j] for j in jobs))
+    
+    reformulation = @dantzig_wolfe model begin
+        x[m, _] => subproblem(m)
+        penalty[_] => master()
+        assignment[_] => master()
+        capacity_constr[m] => subproblem(m)
+    end
+    
+    @test reformulation isa RK.DantzigWolfeReformulation
+    @test length(RK.subproblems(reformulation)) == 2
+    
+    master = RK.master(reformulation)
+    @test JuMP.num_variables(master) == 3  # penalty variables
+    @test haskey(master.obj_dict, :penalty)
+    @test haskey(master.obj_dict, :assignment)
+    
+    subproblems = RK.subproblems(reformulation)
+    for (m, sp) in subproblems
+        @test JuMP.num_variables(sp) == 3  # x variables for 3 jobs
+        @test haskey(sp.obj_dict, :x)
+        @test haskey(sp.obj_dict, :capacity_constr)
+    end
+end
+
+function test_macro_single_index_patterns_ok()
+    model = Model()
+    @variable(model, y[1:3])
+    @constraint(model, single_constr[i in 1:3], y[i] <= 1)
+    @constraint(model, master_constr, sum(y) >= 1)
+    @objective(model, Min, sum(y))
+    
+    reformulation = @dantzig_wolfe model begin
+        y[i] => subproblem(i)
+        single_constr[i] => subproblem(i)
+        master_constr => master()
+    end
+    
+    @test reformulation isa RK.DantzigWolfeReformulation
+    @test length(RK.subproblems(reformulation)) == 3
+    
+    for i in 1:3
+        sp = RK.subproblems(reformulation)[i]
+        @test JuMP.num_variables(sp) == 1
+        @test haskey(sp.obj_dict, :y)
+        @test haskey(sp.obj_dict, :single_constr)
+    end
+end
+
+function test_macro_no_index_patterns_ok()
+    model = Model()
+    @variable(model, x)
+    @variable(model, y)
+    @constraint(model, link, x + y <= 1)
+    @objective(model, Min, x + y)
+    
+    reformulation = @dantzig_wolfe model begin
+        x => subproblem(1)
+        y => master()
+        link => master()
+    end
+    
+    @test reformulation isa RK.DantzigWolfeReformulation
+    @test length(RK.subproblems(reformulation)) == 1
+    
+    master = RK.master(reformulation)
+    @test haskey(master.obj_dict, :y)
+    @test haskey(master.obj_dict, :link)
+    
+    sp = RK.subproblems(reformulation)[1]
+    @test haskey(sp.obj_dict, :x)
+end
+
+function test_macro_error_malformed_pattern_nok()
+    model = Model()
+    @variable(model, x)
+    
+    @test_throws Exception @eval @dantzig_wolfe $model begin
+        invalid_pattern => subproblem(1)
+    end
+end
+
+function test_macro_error_malformed_assignment_nok()
+    model = Model()
+    @variable(model, x)
+    
+    @test_throws Exception @eval @dantzig_wolfe $model begin
+        x => invalid_assignment(1)
+    end
+end
+
+function test_macro_error_subproblem_no_args_nok()
+    model = Model()
+    @variable(model, x)
+    
+    @test_throws Exception @eval @dantzig_wolfe $model begin
+        x => subproblem()
+    end
+end
+
+function test_macro_error_master_with_args_nok()
+    model = Model()
+    @variable(model, x)
+    
+    @test_throws Exception @eval @dantzig_wolfe $model begin
+        x => master(1)
+    end
+end
+
+function test_macro_error_empty_block_nok()
+    model = Model()
+    @variable(model, x)
+    
+    @test_throws Exception @eval @dantzig_wolfe $model begin
+    end
+end
+
+function test_macro_compatibility_with_callback_functions_ok()
+    J = 1:2
+    M = 1:2
+    c = [1 2; 3 4]
+    
+    model = Model()
+    @variable(model, x[M, J], Bin)
+    @constraint(model, assignment[j in J], sum(x[m, j] for m in M) >= 1)
+    @constraint(model, capacity[m in M], sum(x[m, j] for j in J) <= 2)
+    @objective(model, Min, sum(c[m, j] * x[m, j] for m in M, j in J))
+    
+    # Test macro version
+    macro_reformulation = @dantzig_wolfe model begin
+        x[m, _] => subproblem(m)
+        assignment[_] => master()
+        capacity[m] => subproblem(m)
+    end
+    
+    # Test callback version  
+    callback_annotation(::Val{:x}, m, j) = RK.dantzig_wolfe_subproblem(m)
+    callback_annotation(::Val{:assignment}, j) = RK.dantzig_wolfe_master()
+    callback_annotation(::Val{:capacity}, m) = RK.dantzig_wolfe_subproblem(m)
+    
+    callback_reformulation = RK.dantzig_wolfe_decomposition(model, callback_annotation)
+    
+    # Both should produce structurally similar results
+    @test typeof(macro_reformulation) == typeof(callback_reformulation)
+    @test length(RK.subproblems(macro_reformulation)) == length(RK.subproblems(callback_reformulation))
+    
+    macro_master = RK.master(macro_reformulation)
+    callback_master = RK.master(callback_reformulation)
+    @test JuMP.num_variables(macro_master) == JuMP.num_variables(callback_master)
+    
+    macro_sps = RK.subproblems(macro_reformulation)
+    callback_sps = RK.subproblems(callback_reformulation)
+    for m in M
+        @test JuMP.num_variables(macro_sps[m]) == JuMP.num_variables(callback_sps[m])
+    end
+end
+
+function test_macro_multiple_calls_no_conflicts_ok()
+    # Test that multiple macro calls don't interfere with each other
+    
+    # First call
+    model1 = Model()
+    @variable(model1, x[1:2])
+    @constraint(model1, c1, sum(x) <= 1)
+    @objective(model1, Min, sum(x))
+    
+    reformulation1 = @dantzig_wolfe model1 begin
+        x[i] => subproblem(i)
+        c1 => master()
+    end
+    
+    # Second call with different patterns
+    model2 = Model()
+    @variable(model2, y[1:3, 1:2])
+    @constraint(model2, assignment[j in 1:2], sum(y[i, j] for i in 1:3) >= 1)
+    @constraint(model2, capacity[i in 1:3], sum(y[i, j] for j in 1:2) <= 1)
+    @objective(model2, Min, sum(y))
+    
+    reformulation2 = @dantzig_wolfe model2 begin
+        y[i, _] => subproblem(i)
+        assignment[_] => master()
+        capacity[i] => subproblem(i)
+    end
+    
+    # Both reformulations should be valid and independent
+    @test reformulation1 isa RK.DantzigWolfeReformulation
+    @test reformulation2 isa RK.DantzigWolfeReformulation
+    @test length(RK.subproblems(reformulation1)) == 2
+    @test length(RK.subproblems(reformulation2)) == 3
+end
+
+function test_unit_macro()
+    @testset "[macro] basic functionality" begin
+        test_macro_basic_gap_ok()
+        test_macro_gap_with_penalties_ok()
+        #test_macro_single_index_patterns_ok()
+        #test_macro_no_index_patterns_ok()
+    end
+    
+    @testset "[macro] error handling" begin
+        test_macro_error_malformed_pattern_nok()
+        test_macro_error_malformed_assignment_nok()
+        test_macro_error_subproblem_no_args_nok()
+        test_macro_error_master_with_args_nok()
+        test_macro_error_empty_block_nok()
+    end
+    
+    @testset "[macro] compatibility and isolation" begin
+        test_macro_compatibility_with_callback_functions_ok()
+        #test_macro_multiple_calls_no_conflicts_ok()
+    end
+end

--- a/test/ReformulationKitUnitTests/dantzig_wolfe/macro.jl
+++ b/test/ReformulationKitUnitTests/dantzig_wolfe/macro.jl
@@ -244,8 +244,8 @@ function test_unit_macro()
     @testset "[macro] basic functionality" begin
         test_macro_basic_gap_ok()
         test_macro_gap_with_penalties_ok()
-        #test_macro_single_index_patterns_ok()
-        #test_macro_no_index_patterns_ok()
+        test_macro_single_index_patterns_ok()
+        test_macro_no_index_patterns_ok()
     end
     
     @testset "[macro] error handling" begin
@@ -258,6 +258,6 @@ function test_unit_macro()
     
     @testset "[macro] compatibility and isolation" begin
         test_macro_compatibility_with_callback_functions_ok()
-        #test_macro_multiple_calls_no_conflicts_ok()
+        test_macro_multiple_calls_no_conflicts_ok()
     end
 end

--- a/test/ReformulationKitUnitTests/dantzig_wolfe/partitionning.jl
+++ b/test/ReformulationKitUnitTests/dantzig_wolfe/partitionning.jl
@@ -56,7 +56,7 @@ function test_master_variables_empty_ok()
     
     result = RK._master_variables(model, gap_annotation)
     
-    @test result isa Dict{Symbol,Set{Tuple}}
+    @test result isa Dict{Symbol,Any}
     @test isempty(result)
 end
 
@@ -65,7 +65,7 @@ function test_master_variables_penalty_vars_ok()
     
     result = RK._master_variables(model, gap_annotation)
     
-    @test result isa Dict{Symbol,Set{Tuple}}
+    @test result isa Dict{Symbol,Any}
     @test haskey(result, :penalty)
     @test result[:penalty] == Set([(j,) for j in jobs])
 end
@@ -75,7 +75,7 @@ function test_master_variables_mixed_dimensions_ok()
     
     result = RK._master_variables(model, mixed_gap_annotation)
     
-    @test result isa Dict{Symbol,Set{Tuple}}
+    @test result isa Dict{Symbol,Any}
     @test haskey(result, :z)
     @test result[:z] == Set([(j,) for j in jobs])
 end
@@ -86,7 +86,7 @@ function test_partition_subproblem_variables_assignment_vars_ok()
     
     result = RK._partition_subproblem_variables(model, gap_annotation)
     
-    @test result isa Dict{Any,Dict{Symbol,Set{Tuple}}}
+    @test result isa Dict{Any,Dict{Symbol,Any}}
     @test length(result) == length(machines)
     for m in machines
         @test haskey(result, m)
@@ -123,7 +123,7 @@ function test_master_constraints_assignment_constraints_ok()
     
     result = RK._master_constraints(model, gap_annotation)
     
-    @test result isa Dict{Symbol,Set{Tuple}}
+    @test result isa Dict{Symbol,Any}
     @test haskey(result, :assignment)
     @test result[:assignment] == Set([(j,) for j in jobs])
 end
@@ -136,7 +136,7 @@ function test_master_constraints_empty_ok()
     
     result = RK._master_constraints(model, gap_annotation)
     
-    @test result isa Dict{Symbol,Set{Tuple}}
+    @test result isa Dict{Symbol,Any}
     @test isempty(result)
 end
 
@@ -146,7 +146,7 @@ function test_partition_subproblem_constraints_capacity_ok()
     
     result = RK._partition_subproblem_constraints(model, gap_annotation)
     
-    @test result isa Dict{Any,Dict{Symbol,Set{Tuple}}}
+    @test result isa Dict{Any,Dict{Symbol,Any}}
     @test length(result) == length(machines)
     for m in machines
         @test haskey(result, m)
@@ -173,9 +173,9 @@ function test_master_variables_scalar_ok()
     
     result = RK._master_variables(model, scalar_master_annotation)
     
-    @test result isa Dict{Symbol,Set{Tuple}}
+    @test result isa Dict{Symbol,Any}
     @test haskey(result, :scalar_master_var)
-    @test result[:scalar_master_var] == Set{Tuple}([()]) # Should contain empty tuple, not be empty
+    @test result[:scalar_master_var] == Set{Tuple{}}([()]) # Should contain empty tuple, not be empty
     @test length(result[:scalar_master_var]) == 1
     @test () in result[:scalar_master_var]
 end
@@ -185,10 +185,10 @@ function test_partition_subproblem_variables_scalar_ok()
     
     result = RK._partition_subproblem_variables(model, scalar_subproblem_annotation)
     
-    @test result isa Dict{Any,Dict{Symbol,Set{Tuple}}}
+    @test result isa Dict{Any,Dict{Symbol,Any}}
     @test haskey(result, 1)
     @test haskey(result[1], :scalar_sp_var)
-    @test result[1][:scalar_sp_var] == Set{Tuple}([()]) # Should contain empty tuple, not be empty
+    @test result[1][:scalar_sp_var] == Set{Tuple{}}([()]) # Should contain empty tuple, not be empty
     @test length(result[1][:scalar_sp_var]) == 1
     @test () in result[1][:scalar_sp_var]
 end
@@ -199,9 +199,9 @@ function test_master_constraints_scalar_ok()
     
     result = RK._master_constraints(model, scalar_master_annotation)
     
-    @test result isa Dict{Symbol,Set{Tuple}}
+    @test result isa Dict{Symbol,Any}
     @test haskey(result, :scalar_master_constraint)
-    @test result[:scalar_master_constraint] == Set{Tuple}([()]) # Should contain empty tuple, not be empty
+    @test result[:scalar_master_constraint] == Set{Tuple{}}([()]) # Should contain empty tuple, not be empty
     @test length(result[:scalar_master_constraint]) == 1
     @test () in result[:scalar_master_constraint]
 end
@@ -211,10 +211,10 @@ function test_partition_subproblem_constraints_scalar_ok()
     
     result = RK._partition_subproblem_constraints(model, scalar_subproblem_annotation)
     
-    @test result isa Dict{Any,Dict{Symbol,Set{Tuple}}}
+    @test result isa Dict{Any,Dict{Symbol,Any}}
     @test haskey(result, 1)
     @test haskey(result[1], :scalar_sp_constraint)
-    @test result[1][:scalar_sp_constraint] == Set{Tuple}([()]) # Should contain empty tuple, not be empty
+    @test result[1][:scalar_sp_constraint] == Set{Tuple{}}([()]) # Should contain empty tuple, not be empty
     @test length(result[1][:scalar_sp_constraint]) == 1
     @test () in result[1][:scalar_sp_constraint]
 end


### PR DESCRIPTION
## Summary
- Add declarative syntax for Dantzig-Wolfe decomposition
- Replace callback functions with pattern matching syntax
- Generate multiple method definitions using Julia's dispatch

## Example
```julia
@dantzig_wolfe model begin
    assignment[m, _] => subproblem(m)
    capacity[m] => subproblem(m)
    coverage[_] => master()
end
```